### PR TITLE
A couple of fixes for mod core

### DIFF
--- a/redbot/cogs/mod/checks.py
+++ b/redbot/cogs/mod/checks.py
@@ -30,7 +30,7 @@ def admin_or_voice_permissions(**perms):
     async def pred(ctx: commands.Context):
         author = ctx.author
         guild = ctx.guild
-        if ctx.bot.is_owner(author) or guild.owner == author:
+        if await ctx.bot.is_owner(author) or guild.owner == author:
             return True
         admin_role = discord.utils.get(guild.roles, id=await ctx.bot.db.guild(guild).admin_role())
         if admin_role in author.roles:

--- a/redbot/cogs/mod/filter.py
+++ b/redbot/cogs/mod/filter.py
@@ -121,7 +121,7 @@ class Filter:
                         pass
 
     async def on_message(self, message: discord.Message):
-        if message.channel.guild is None:
+        if isinstance(message.channel, discord.abc.PrivateChannel):
             return
         author = message.author
         valid_user = isinstance(author, discord.Member) and not author.bot

--- a/redbot/cogs/mod/filter.py
+++ b/redbot/cogs/mod/filter.py
@@ -121,6 +121,8 @@ class Filter:
                         pass
 
     async def on_message(self, message: discord.Message):
+        if message.channel.guild is None:
+            return
         author = message.author
         valid_user = isinstance(author, discord.Member) and not author.bot
 

--- a/redbot/cogs/mod/filter.py
+++ b/redbot/cogs/mod/filter.py
@@ -133,7 +133,7 @@ class Filter:
 
     async def on_message_edit(self, _, message):
         author = message.author
-        if message.server is None or self.bot.user == author:
+        if message.guild is None or self.bot.user == author:
             return
 
         valid_user = isinstance(author, discord.Member) and not author.bot

--- a/redbot/core/modlog.py
+++ b/redbot/core/modlog.py
@@ -245,7 +245,7 @@ async def create_case(guild: discord.Guild, created_at: datetime, action_type: s
     mod_channel = None
     if hasattr(guild, "owner"):  # Fairly arbitrary, but it doesn't really matter since we don't need the modlog channel in tests
         try:
-            mod_channel = get_modlog_channel(guild)
+            mod_channel = await get_modlog_channel(guild)
         except RuntimeError:
             raise RuntimeError(
                 "No mod log channel set for guild {}".format(guild.name)


### PR DESCRIPTION
The core commands should work and carry out their functions now, however there is still one issue:

If a command is supposed to create case in the modlog, and the modlog channel isn't set, it will still complete the action, but it will only respond "No mod log channel set for guild *guildname*". And in the case of softban, it does that too, except it doesn't unban the user.