### PR TITLE
(For your Makefile PR) Add make.bat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 reformat:
-	black -l 99 redbot tests setup.py generate_strings.py docs/conf.py
+	black -l 99 `git ls-files "*.py"`
 stylecheck:
-	black --check -l 99 redbot tests setup.py generate_strings.py docs/conf.py
+	black -l 99 --check `git ls-files "*.py"`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 reformat:
 	black -l 99 `git ls-files "*.py"`
 stylecheck:
-	black -l 99 --check `git ls-files "*.py"`
+	black --check -l 99 `git ls-files "*.py"`

--- a/make.bat
+++ b/make.bat
@@ -5,8 +5,8 @@ if "%1"=="" goto help
 REM This allows us to expand variables at execution
 setlocal ENABLEDELAYEDEXPANSION
 
-rem This will set PYFILES as a list of tracked .py files
-REM PYFILES=
+REM This will set PYFILES as a list of tracked .py files
+set PYFILES=
 for /F "tokens=* USEBACKQ" %%A in (`git ls-files "*.py"`) do (
     set PYFILES=!PYFILES! %%A
 )
@@ -15,11 +15,11 @@ goto %1
 
 :reformat
 black -l 99 !PYFILES!
-EXIT /B %ERRORLEVEL%
+exit /B %ERRORLEVEL%
 
 :stylecheck
 black -l 99 --check !PYFILES!
-EXIT /B %ERRORLEVEL%
+exit /B %ERRORLEVEL%
 
 :help
 echo Usage:

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,30 @@
+@echo off
+
+if "%1"=="" goto help
+
+REM This allows us to expand variables at execution
+setlocal ENABLEDELAYEDEXPANSION
+
+rem This will set PYFILES as a list of tracked .py files
+REM PYFILES=
+for /F "tokens=* USEBACKQ" %%A in (`git ls-files "*.py"`) do (
+    set PYFILES=!PYFILES! %%A
+)
+
+goto %1
+
+:reformat
+black -l 99 !PYFILES!
+EXIT /B %ERRORLEVEL%
+
+:stylecheck
+black -l 99 --check !PYFILES!
+EXIT /B %ERRORLEVEL%
+
+:help
+echo Usage:
+echo   make ^<command^>
+echo.
+echo Commands:
+echo   reformat                   Reformat all .py files being tracked by git.
+echo   stylecheck                 Check which tracked .py files need reformatting.

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,10 @@ commands =
 description = Stylecheck the code with black to see if anything needs changes.
 whitelist_externals =
     make
-passenv =
-    PATHEXT
+setenv =
+    # This is just for Windows
+    # Prioritise make.bat over any make.exe which might be on PATH
+    PATHEXT=.BAT;.EXE
 basepython = python3.6
 extras = style
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py35
     py36
     docs
-    dev
+    style
 
 [testenv]
 description = Run unit tests with pytest
@@ -31,7 +31,11 @@ commands =
 
 [testenv:style]
 description = Stylecheck the code with black to see if anything needs changes.
+whitelist_externals =
+    make
+passenv =
+    PATHEXT
 basepython = python3.6
 extras = style
 commands =
-    black -l 99 --check generate_strings.py setup.py tests redbot
+    make stylecheck


### PR DESCRIPTION
I tried to format make.bat so it closely mimics the Makefile.

I also did some other things:
 - The command `git ls-files "*.py"` lists all the tracked python files - we can use this to list files we need to pass to black (admittedly 100 times easier to do in Bash than Batch).
 - Tox now calls `make stylecheck`
